### PR TITLE
added delay script

### DIFF
--- a/flight/mcu/platformio.ini
+++ b/flight/mcu/platformio.ini
@@ -48,6 +48,7 @@ platform = teensy
 board = teensy41
 framework = arduino
 upload_protocol = teensy-cli
+extra_scripts = extra_script.py
 
 lib_deps =
 	PaulStoffregen/PWMServo


### PR DESCRIPTION
Fixes the hang at "if you don't see any output for 10 seconds"
tests should run now if you set the teensy version correctly