### PR TITLE
[AV-182] Switch thread sleep mechanism to wait for a global system time

### DIFF
--- a/flight/mcu/src/mcu_ac/main.cpp
+++ b/flight/mcu/src/mcu_ac/main.cpp
@@ -169,7 +169,10 @@ static THD_FUNCTION(gps_THD, arg) {
         Serial.println("### GPS thread exit");
 #endif
 
-        chThdSleepUntil(next_wakeup_time);
+        // If system time is not inside the window between curr_wakeup_time and
+        // next_wakeup_time, then no sleep is performed. Prevents thread from
+        // locking when next_wakeup_time is overshot.
+        chThdSleepUntilWindowed(curr_wakeup_time, next_wakeup_time);
     }
 }
 
@@ -278,7 +281,10 @@ static THD_FUNCTION(dataLogger_THD, arg) {
 
         dataLoggerTickFunction(pointer_struct);
 
-        chThdSleepUntil(next_wakeup_time);
+        // If system time is not inside the window between curr_wakeup_time and
+        // next_wakeup_time, then no sleep is performed. Prevents thread from
+        // locking when next_wakeup_time is overshot.
+        chThdSleepUntilWindowed(curr_wakeup_time, next_wakeup_time);
     }
 }
 


### PR DESCRIPTION
This PR refactors the way threads sleep. Instead of sleeping for a constant arbitrary duration, the threads are put to sleep and woken up at a particular system time.

This is a much better way to manage thread tick rates as it _does not_ depend on how long the thread internals take to execute.